### PR TITLE
Add support to recieve specific gcpConfig in http

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -15,6 +15,13 @@
     "accessKeyId": "REPLACED_BY_ENV",
     "secretAccessKey": "REPLACED_BY_ENV"
   },
+  "gcpConfigs": {
+    "credentials": {
+      "url": "https://bn-credentials-test.bnu.bn.nr",
+      "audience": "credentials-test-audience",
+      "cloudRunUrl": "https://bn-credentials-test.app.run"
+    }
+  },
   "proxyUrl": "http://api.example.com",
   "awsProxyUrl": "http://api.example-aws.com",
   "gcpProxy": {
@@ -22,6 +29,7 @@
     "audience": "test-audience.apps.googleusercontent.com"
   },
   "livesInGcp": [
+    "credentials",
     "gcp",
     "gcp-app"
   ],

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -64,7 +64,10 @@ async function performRequest(method, params) {
 async function buildHeaders(params, headers = {}) {
   const application = params.path.split("/").find(Boolean);
   if (livesInGcp && livesInGcp.includes(application)) {
-    const gcpHeader = await getGcpAuthHeaders(config.gcpProxy.audience);
+    // We have enabled the possibility to send in a diffenret gcp config to use
+    const conf = params.gcpConfig || config.gcpProxy;
+    // We will firsthand use the cloudRunUrl to go directly to the cloud run url without going trhough a LB out on the web.
+    const gcpHeader = await getGcpAuthHeaders(conf.cloudRunUrl || conf.audience);
     headers = { ...headers, ...gcpHeader };
   }
   const defaults = {
@@ -149,7 +152,9 @@ function withAssertion(verb, fn, params) {
 function getUrl(params) {
   const application = params.path.split("/").find(Boolean);
   if (livesInGcp && livesInGcp.includes(application)) {
-    return `${params.baseUrl || config.gcpProxy.url}${params.path}`;
+    // Enable the usage of sent in cloudRunUrl.
+    const conf = params.gcpConfig || config.gcpProxy;
+    return `${params.baseUrl || conf.cloudRunUrl || conf.url}${params.path}`;
   }
   const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl : config.proxyUrl;
   return `${params.baseUrl || proxyUrl}${params.path}`;

--- a/test/helpers/fake-gcp-auth.js
+++ b/test/helpers/fake-gcp-auth.js
@@ -15,10 +15,10 @@ function init() {
 
 function authenticated() {
   init();
-  stub.getIdTokenClient = () => {
+  stub.getIdTokenClient = (audience) => {
     return {
       getRequestHeaders: () => {
-        return { Authorization: "Bearer some-gcp-token" };
+        return { Authorization: `Bearer ${audience}` };
       },
     };
   };


### PR DESCRIPTION
**Checklist**
- [] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

Write the description and the reason for this PR below ↓
---
Enables us to send in a specific gcpConfig to use as url and audience. This to support using common http when 
calling other teams apps in GCP, e.g. credentials, and they want us to use the cloud run url instead of LB url 
if the app lives in gcp.
