### PR TITLE
If we call credentials from AWS don't get gcp headers

### DIFF
--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -66,7 +66,7 @@ async function performRequest(method, params) {
 
 async function buildHeaders(params, headers = {}) {
   const application = params.path.split("/").find(Boolean);
-  if (livesInGcp && livesInGcp.includes(application) && (application === "credentials" && config.livesIn === "GCP")) {
+  if (livesInGcp && livesInGcp.includes(application) && !(application === "credentials" && config.livesIn !== "GCP")) {
     // We have enabled the possibility to send in a diffenret gcp config to use
     const conf = params.gcpConfig || config.gcpProxy;
     // If we live in GCP, we will firsthand use the cloudRunUrl
@@ -161,7 +161,8 @@ function getUrl(params) {
     const conf = params.gcpConfig || config.gcpProxy;
     // If we send in a baseUrl, always use that. Then if we live in GCP look if we should call the cloudRun url
     // If not then call the loadbalancer url.
-    return `${params.baseUrl || config.livesIn === "GCP" ? conf.cloudRunUrl || conf.url : conf.url}${params.path}`;
+    if (params.baseUrl) return `${params.baseUrl}${params.path}`;
+    return `${config.livesIn === "GCP" ? conf.cloudRunUrl || conf.url : conf.url}${params.path}`;
   }
   const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl : config.proxyUrl;
   return `${params.baseUrl || proxyUrl}${params.path}`;

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -66,6 +66,8 @@ async function performRequest(method, params) {
 
 async function buildHeaders(params, headers = {}) {
   const application = params.path.split("/").find(Boolean);
+  // TEMP: For now as long as entity-api in lu-greenfield also lives in AWS, we have to make this specific check
+  // for credentials, otherwise we won't be able to call them from the AWS instance.
   if (livesInGcp && livesInGcp.includes(application) && !(application === "credentials" && config.livesIn !== "GCP")) {
     // We have enabled the possibility to send in a diffenret gcp config to use
     const conf = params.gcpConfig || config.gcpProxy;

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -66,7 +66,7 @@ async function performRequest(method, params) {
 
 async function buildHeaders(params, headers = {}) {
   const application = params.path.split("/").find(Boolean);
-  if (livesInGcp && livesInGcp.includes(application)) {
+  if (livesInGcp && livesInGcp.includes(application) && (application === "credentials" && config.livesIn === "GCP")) {
     // We have enabled the possibility to send in a diffenret gcp config to use
     const conf = params.gcpConfig || config.gcpProxy;
     // If we live in GCP, we will firsthand use the cloudRunUrl

--- a/test/unit/utils/http-test.js
+++ b/test/unit/utils/http-test.js
@@ -379,7 +379,6 @@ describe("http", () => {
   describe("call other teams gcp with audience, because we don't live in GCP, with sent-in gcpConfig", () => {
     before(() => {
       config.livesIn = "NOT-GCP";
-      fakeGcpAuth.authenticated();
       credentialsLoadBalancerFakeApi.reset();
     });
     beforeEach(fakeGcpAuth.authenticated);
@@ -391,7 +390,7 @@ describe("http", () => {
     const gcpConfig = config.gcpConfigs.credentials;
 
     it("should do get-requests", async () => {
-      credentialsLoadBalancerFakeApi.get("/credentials/some/path").reply(200, { ok: true }).matchHeader("authorization", `Bearer ${gcpConfig.audience}`);
+      credentialsLoadBalancerFakeApi.get("/credentials/some/path").reply(200, { ok: true });
       const result = await http.get({ path: "/credentials/some/path", gcpConfig, correlationId });
       result.body.should.eql({ ok: true });
     });


### PR DESCRIPTION
**Checklist**
- [x] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

Write the description and the reason for this PR below ↓
---
To have some backwards compatability with our AWS instances calling credentials in GCP.
