### PR TITLE
Always default to proxyUrl if awsProxyUrl isn't set

### DIFF
--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -166,7 +166,7 @@ function getUrl(params) {
     if (params.baseUrl) return `${params.baseUrl}${params.path}`;
     return `${config.livesIn === "GCP" ? conf.cloudRunUrl || conf.url : conf.url}${params.path}`;
   }
-  const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl : config.proxyUrl;
+  const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl || config.proxyUrl : config.proxyUrl;
   return `${params.baseUrl || proxyUrl}${params.path}`;
 }
 


### PR DESCRIPTION
**Checklist**
- [ ] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

Write the description and the reason for this PR below ↓
---
Makes it possible to not have to set a config variable called awsProxyUrl, and if not then 
default to proxyUrl
