### PR TITLE
fake-api checks for auth header when in GCP

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -6,8 +6,8 @@
     "test",
     "test-data"
   ],
-  "statements": "50",
-  "branches": "90",
-  "functions": "33",
-  "lines": "50"
+  "statements": "54",
+  "branches": "91",
+  "functions": "37",
+  "lines": "54"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-common",
-  "version": "3.10.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-common",
-      "version": "3.10.2",
+      "version": "4.0.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^5.18.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-common",
-  "version": "3.10.2",
+  "version": "4.0.0",
   "description": "",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
fake-api routines now require the Authorization header to be set (with a Bearer token) when the project uses the gcp proxy.