### PR TITLE
Bump ssh2-sftp-client to ^9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-common",
-  "version": "5.1.3",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-common",
-      "version": "5.1.3",
+      "version": "6.0.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^5.18.3",
@@ -24,7 +24,7 @@
         "nock": "^13.3.8",
         "pdfkit": "^0.14.0",
         "sinon": "^17.0.1",
-        "ssh2-sftp-client": "^7.2.3",
+        "ssh2-sftp-client": "^9.1.0",
         "swedish-holidays": "^1.1.2",
         "urlencode": "^1.1.0"
       },
@@ -6261,13 +6261,13 @@
       }
     },
     "node_modules/ssh2-sftp-client": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-7.2.3.tgz",
-      "integrity": "sha512-Bmq4Uewu3e0XOwu5bnPbiS5KRQYv+dff5H6+85V4GZrPrt0Fkt1nUH+uXanyAkoNxUpzjnAPEEoLdOaBO9c3xw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.1.0.tgz",
+      "integrity": "sha512-Hzdr9OE6GxZjcmyM9tgBSIFVyrHAp9c6U2Y4yBkmYOHoQvZ7pIm27dmltvcmRfxcWiIcg8HBvG5iAikDf+ZuzQ==",
       "dependencies": {
         "concat-stream": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "ssh2": "^1.8.0"
+        "ssh2": "^1.12.0"
       },
       "engines": {
         "node": ">=10.24.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-common",
-  "version": "5.1.3",
+  "version": "6.0.0",
   "description": "",
   "main": "index.js",
   "engines": {
@@ -34,7 +34,7 @@
     "nock": "^13.3.8",
     "pdfkit": "^0.14.0",
     "sinon": "^17.0.1",
-    "ssh2-sftp-client": "^7.2.3",
+    "ssh2-sftp-client": "^9.1.0",
     "swedish-holidays": "^1.1.2",
     "urlencode": "^1.1.0"
   },


### PR DESCRIPTION
- Requires that the client application also uses ssh2-sftp-client ^9.1.0