### PR TITLE
Remove special case for credentials in HTTP GCP headers

### DIFF
--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -66,9 +66,7 @@ async function performRequest(method, params) {
 
 async function buildHeaders(params, headers = {}) {
   const application = params.path.split("/").find(Boolean);
-  // TEMP: For now as long as entity-api in lu-greenfield also lives in AWS, we have to make this specific check
-  // for credentials, otherwise we won't be able to call them from the AWS instance.
-  if (livesInGcp && livesInGcp.includes(application) && !(application === "credentials" && config.livesIn !== "GCP")) {
+  if (livesInGcp && livesInGcp.includes(application)) {
     // We have enabled the possibility to send in a diffenret gcp config to use
     const conf = params.gcpConfig || config.gcpProxy;
     // If we live in GCP, we will firsthand use the cloudRunUrl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-common",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-common",
-      "version": "6.0.2",
+      "version": "6.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^5.18.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-common",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
**Checklist**
- [ ] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

Write the description and the reason for this PR below ↓
---
We can use their IAP and thus no longer need the special case for AWS