### PR TITLE
Remove livesIn and livesInGcp functionality

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -6,8 +6,8 @@
     "test/helpers",
     "test-data"
   ],
-  "statements": "71",
+  "statements": "68",
   "branches": "97",
   "functions": "40",
-  "lines": "71"
+  "lines": "68"
 }

--- a/config/test.json
+++ b/config/test.json
@@ -8,8 +8,7 @@
   "gcs": {
     "bucket": "test-bucket",
     "credentials": {
-      "projectId": "some-project-1234",
-      "keyFilename": "/etc/fake-keyfile.json"
+      "projectId": "some-project-1234"
     }
   },
   "ses": {
@@ -23,13 +22,10 @@
       "cloudRunUrl": "https://bn-credentials-test.app.run"
     }
   },
-  "proxyUrl": "http://api.example.com",
-  "awsProxyUrl": "http://api.example-aws.com",
   "gcpProxy": {
     "url": "https://greenfield-test.bn.nr",
     "audience": "test-audience.apps.googleusercontent.com"
   },
-  "livesInGcp": ["credentials", "gcp", "gcp-app"],
   "logging": {
     "pretty": true
   },

--- a/lib/helpers/code-helper.js
+++ b/lib/helpers/code-helper.js
@@ -1,15 +1,9 @@
 import config from "exp-config";
 
-const { livesInGcp } = config;
-
 const enumerate = (arr) => arr.map((value, index) => [ index, value ]);
 
 const getUrl = (params) => {
-  const application = params.path.split("/").find(Boolean);
-  if (livesInGcp?.includes(application)) {
-    return `${params.baseUrl || config.gcpProxy.url}${params.path}`;
-  }
-  return `${params.baseUrl || config.proxyUrl}${params.path}`;
+  return `${params.baseUrl || config.gcpProxy.url}${params.path}`;
 };
 
 export { enumerate, getUrl };

--- a/lib/utils/gcs.js
+++ b/lib/utils/gcs.js
@@ -24,8 +24,6 @@ function metadata(uri) {
 
 function getCredentials(configName = "gcs") {
   const credentials = JSON.parse(JSON.stringify(config[configName].credentials));
-  if (config.livesIn === "GCP") delete credentials.keyFilename;
-
   return credentials;
 }
 

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -6,8 +6,6 @@ import assert from "assert";
 
 import { getGcpAuthHeaders } from "./gcp-auth.js";
 
-const { livesInGcp } = config;
-
 const backends = buildBackends();
 
 async function performRequest(method, params) {
@@ -68,16 +66,14 @@ async function performRequest(method, params) {
 }
 
 async function buildHeaders(params, headers = {}) {
-  const application = params.path.split("/").find(Boolean);
-  if (livesInGcp && livesInGcp.includes(application)) {
-    // We have enabled the possibility to send in a diffenret gcp config to use
-    const conf = params.gcpConfig || config.gcpProxy;
-    // If we live in GCP, we will firsthand use the cloudRunUrl
-    // This so we go directly to the cloud run url without going through a LB out on the web.
-    const audienceOrUrl = config.livesIn === "GCP" ? conf.cloudRunUrl || conf.audience : conf.audience;
-    const gcpHeader = await getGcpAuthHeaders(audienceOrUrl);
-    headers = { ...headers, ...gcpHeader };
-  }
+  // We have enabled the possibility to send in a different gcp config to use
+  const conf = params.gcpConfig || config.gcpProxy;
+  // We will firsthand use the cloudRunUrl
+  // This so we go directly to the cloud run url without going through a LB out on the web.
+  const audienceOrUrl = conf.cloudRunUrl || conf.audience;
+  let gcpHeader = {};
+  if (!params.baseUrl && audienceOrUrl) gcpHeader = await getGcpAuthHeaders(audienceOrUrl);
+  headers = { ...headers, ...gcpHeader };
   const defaults = {
     accept: "application/json",
     "correlation-id": params.correlationId,
@@ -159,17 +155,12 @@ function withAssertion(verb, fn, params) {
 }
 
 function getUrl(params) {
-  const application = params.path.split("/").find(Boolean);
-  if (livesInGcp && livesInGcp.includes(application)) {
-    // Enable the usage of sent in gcpConfig and cloudRunUrl.
-    const conf = params.gcpConfig || config.gcpProxy;
-    // If we send in a baseUrl, always use that. Then if we live in GCP look if we should call the cloudRun url
-    // If not then call the loadbalancer url.
-    if (params.baseUrl) return `${params.baseUrl}${params.path}`;
-    return `${config.livesIn === "GCP" ? conf.cloudRunUrl || conf.url : conf.url}${params.path}`;
-  }
-  const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl || config.proxyUrl : config.proxyUrl;
-  return `${params.baseUrl || proxyUrl}${params.path}`;
+  // Enable the usage of sent in gcpConfig and cloudRunUrl.
+  const conf = params.gcpConfig || config.gcpProxy;
+  // If we send in a baseUrl, always use that. Then look if we should call the cloudRun url
+  // If not then call the loadbalancer url.
+  if (params.baseUrl) return `${params.baseUrl}${params.path}`;
+  return `${conf.cloudRunUrl || conf.url}${params.path}`;
 }
 
 export default backends;

--- a/test/helpers/fake-api.js
+++ b/test/helpers/fake-api.js
@@ -5,7 +5,7 @@ import fs from "fs";
 import stream from "stream";
 import zlib from "zlib";
 
-const proxyUrl = config.livesIn === "GCP" ? config.gcpProxy?.url : config.proxyUrl || config.awsProxyUrl;
+const proxyUrl = config.gcpProxy.url;
 
 function init(url = proxyUrl) {
   let api = nock(url);

--- a/test/unit/helpers/code-helper-test.js
+++ b/test/unit/helpers/code-helper-test.js
@@ -26,11 +26,6 @@ describe("Get url based on where the application lives", () => {
       getUrl({ path: "/gcp-app/some-path" }).should.eql(`${config.gcpProxy.url}/gcp-app/some-path`);
     });
   });
-  describe("when getting an url with an application that doesn't yet live in gcp", () => {
-    it("we hould get the normal proxyurl", () => {
-      getUrl({ path: "/some-app/some-path" }).should.eql(`${config.proxyUrl}/some-app/some-path`);
-    });
-  });
   describe("when getting an url with a sent in baseUrl", () => {
     it("we should use the baseUrl that was sent in", () => {
       getUrl({ path: "/some-app/some-path", baseUrl: "http://some-base-url" }).should.eql(

--- a/test/unit/utils/gcs-test.js
+++ b/test/unit/utils/gcs-test.js
@@ -3,21 +3,9 @@ import config from "exp-config";
 import { getCredentials } from "../../../lib/utils/gcs.js";
 
 describe("gcs", () => {
-  it("should return whole credentials object for AWS", () => {
-    config.livesIn = "AWS";
-    const credentials = getCredentials();
-    credentials.should.eql(config.gcs.credentials);
-    config.livesIn = "GCP";
-  });
-
-  it("should credentials object without keyFilename for GCP", () => {
-    config.livesIn = "GCP";
-
+  it("should credentials object", () => {
     const credentials = getCredentials();
     const expected = JSON.parse(JSON.stringify(config.gcs.credentials));
-    delete expected.keyFilename;
     credentials.should.eql(expected);
-
-    delete config.livesIn;
   });
 });


### PR DESCRIPTION
Remove livesIn / livesInGcp functionality from lu-common.

Temp drop coverage - it will be fixed before v7.0.0 is released for real