### PR TITLE
Remove cloudRunUrl functionality - we always go via the load balancer now

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -6,8 +6,8 @@
     "test/helpers",
     "test-data"
   ],
-  "statements": "71",
+  "statements": "70",
   "branches": "97",
   "functions": "40",
-  "lines": "71"
+  "lines": "70"
 }

--- a/config/test.json
+++ b/config/test.json
@@ -19,8 +19,7 @@
   "gcpConfigs": {
     "credentials": {
       "url": "https://bn-credentials-test.bnu.bn.nr",
-      "audience": "credentials-test-audience",
-      "cloudRunUrl": "https://bn-credentials-test.app.run"
+      "audience": "credentials-test-audience"
     }
   },
   "proxyUrl": "http://api.example.com",

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -72,10 +72,7 @@ async function buildHeaders(params, headers = {}) {
   if (livesInGcp && livesInGcp.includes(application)) {
     // We have enabled the possibility to send in a diffenret gcp config to use
     const conf = params.gcpConfig || config.gcpProxy;
-    // If we live in GCP, we will firsthand use the cloudRunUrl
-    // This so we go directly to the cloud run url without going through a LB out on the web.
-    const audienceOrUrl = config.livesIn === "GCP" ? conf.cloudRunUrl || conf.audience : conf.audience;
-    const gcpHeader = await getGcpAuthHeaders(audienceOrUrl);
+    const gcpHeader = await getGcpAuthHeaders(conf.audience);
     headers = { ...headers, ...gcpHeader };
   }
   const defaults = {
@@ -161,12 +158,12 @@ function withAssertion(verb, fn, params) {
 function getUrl(params) {
   const application = params.path.split("/").find(Boolean);
   if (livesInGcp && livesInGcp.includes(application)) {
-    // Enable the usage of sent in gcpConfig and cloudRunUrl.
+    // Enable the usage of sent in gcpConfig
     const conf = params.gcpConfig || config.gcpProxy;
-    // If we send in a baseUrl, always use that. Then if we live in GCP look if we should call the cloudRun url
+    // If we send in a baseUrl, always use that.
     // If not then call the loadbalancer url.
     if (params.baseUrl) return `${params.baseUrl}${params.path}`;
-    return `${config.livesIn === "GCP" ? conf.cloudRunUrl || conf.url : conf.url}${params.path}`;
+    return `${conf.url}${params.path}`;
   }
   const proxyUrl = config.livesIn === "GCP" ? config.awsProxyUrl || config.proxyUrl : config.proxyUrl;
   return `${params.baseUrl || proxyUrl}${params.path}`;

--- a/test/unit/utils/http-test.js
+++ b/test/unit/utils/http-test.js
@@ -316,7 +316,7 @@ describe("http", () => {
     });
   });
 
-  describe("call other teams gcp with cloudrun url because we live in GCP, with sent-in gcpConfig", () => {
+  describe("call other teams gcp with audience because we live in GCP, with sent-in gcpConfig", () => {
     before(() => {
       config.livesIn = "GCP";
     });

--- a/test/unit/utils/http-test.js
+++ b/test/unit/utils/http-test.js
@@ -308,19 +308,5 @@ describe("http", () => {
     });
   });
 
-  describe("lives in GCP", () => {
-    beforeEach(fakeGcpAuth.authenticated);
-    after(fakeGcpAuth.reset);
-    const correlationId = "http-gcp-config";
-    const gcpConfig = clone(config.gcpConfigs.credentials);
-    delete gcpConfig.cloudRunUrl;
-
-    it("should do get-requests", async () => {
-      credentialsLoadBalancerFakeApi.get("/credentials/some/path").reply(200, { ok: true });
-      const result = await http.get({ path: "/credentials/some/path", gcpConfig, correlationId });
-      result.body.should.eql({ ok: true });
-    });
-  });
-
   afterEach(fakeApi.reset);
 });


### PR DESCRIPTION
cloudRunUrl is no longer used anywhere, so get rid of that functionality.

Temp drop coverage - it will be fixed before v7.0.0 is released for real
