### PR TITLE
Export s3 and ses functions as an object so that sinon can mock them with ES6

### DIFF
--- a/lib/utils/s3.js
+++ b/lib/utils/s3.js
@@ -115,5 +115,7 @@ function toPath(
   )}${subDirectories}/${fileName}`;
 }
 
-export { toLakeDate, existsV2, readStreamV2, s3FileStreamV2, toPath, parseUri, listObjectsAsync };
+// we have to export utils as well to make it possible to mock the functions in tests with ES6
+const utils = { toLakeDate, existsV2, readStreamV2, s3FileStreamV2, toPath, parseUri, listObjectsAsync };
+export { toLakeDate, existsV2, readStreamV2, s3FileStreamV2, toPath, parseUri, listObjectsAsync, utils };
 /* c8 ignore stop */

--- a/lib/utils/ses.js
+++ b/lib/utils/ses.js
@@ -20,5 +20,7 @@ const sendRawEmail = async (namespace, params) => {
   return await awsSes.sendRawEmail(params).promise();
 };
 
-export { sendEmail, sendRawEmail };
+// we have to export utils as well to make it possible to mock the functions in tests with ES6
+const utils = { sendEmail, sendRawEmail };
+export { sendEmail, sendRawEmail, utils };
 /* c8 ignore stop */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-common",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-common",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-common",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/test/helpers/fake-s3.js
+++ b/test/helpers/fake-s3.js
@@ -5,7 +5,7 @@ import es from "event-stream";
 import { createSandbox } from "sinon";
 import assert from "assert";
 
-import * as s3 from "../../lib/utils/s3.js";
+import { utils as s3 } from "../../lib/utils/s3.js";
 
 const sandbox = createSandbox();
 

--- a/test/helpers/fake-ses.js
+++ b/test/helpers/fake-ses.js
@@ -2,7 +2,7 @@
 // Reason: we'll soon be moving this functionaltiy to Google's smtp
 import { createSandbox } from "sinon";
 
-import * as ses from "../../lib/utils/ses.js";
+import { utils as ses } from "../../lib/utils/ses.js";
 
 const sandbox = createSandbox();
 


### PR DESCRIPTION
sinon can't stub ES6 modules, but it can stub functions from an object. So we export ses and s3 functions as a utils object and use that in fake-ses and fake-s3.