### PR TITLE
Allow manually setting GCP auth header

### DIFF
--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -65,17 +65,21 @@ async function performRequest(method, params) {
 }
 
 async function buildHeaders(params, headers = {}) {
-  const application = params.path.split("/").find(Boolean);
-  // TEMP: For now as long as entity-api in lu-greenfield also lives in AWS, we have to make this specific check
-  // for credentials, otherwise we won't be able to call them from the AWS instance.
-  if (livesInGcp && livesInGcp.includes(application) && !(application === "credentials" && config.livesIn !== "GCP")) {
+  if (!headers.Authorization) {
+    // don't try getting GCP Authorization headers if we already have an Authorization header
+    // this lets us run scripts locally by sending in an Authorization header
+    const application = params.path.split("/").find(Boolean);
+    // TEMP: For now as long as entity-api in lu-greenfield also lives in AWS, we have to make this specific check
+    // for credentials, otherwise we won't be able to call them from the AWS instance.
+    if (livesInGcp && livesInGcp.includes(application) && !(application === "credentials" && config.livesIn !== "GCP")) {
     // We have enabled the possibility to send in a diffenret gcp config to use
-    const conf = params.gcpConfig || config.gcpProxy;
-    // If we live in GCP, we will firsthand use the cloudRunUrl
-    // This so we go directly to the cloud run url without going through a LB out on the web.
-    const audienceOrUrl = config.livesIn === "GCP" ? conf.cloudRunUrl || conf.audience : conf.audience;
-    const gcpHeader = await getGcpAuthHeaders(audienceOrUrl);
-    headers = { ...headers, ...gcpHeader };
+      const conf = params.gcpConfig || config.gcpProxy;
+      // If we live in GCP, we will firsthand use the cloudRunUrl
+      // This so we go directly to the cloud run url without going through a LB out on the web.
+      const audienceOrUrl = config.livesIn === "GCP" ? conf.cloudRunUrl || conf.audience : conf.audience;
+      const gcpHeader = await getGcpAuthHeaders(audienceOrUrl);
+      headers = { ...headers, ...gcpHeader };
+    }
   }
   const defaults = {
     accept: "application/json",

--- a/test/unit/utils/http-test.js
+++ b/test/unit/utils/http-test.js
@@ -429,6 +429,12 @@ describe("http", () => {
       result.should.eql({ ok: true });
     });
 
+    it("should do get-requests with a manually added Auth header", async () => {
+      gcpFakeApi.get("/gcp/some/path").reply(200, { ok: true });
+      const result = await http.asserted.get({ path: "/gcp/some/path", headers: { Authorization: "Bearer some-cool-token" }, correlationId });
+      result.should.eql({ ok: true });
+    });
+
     it("should do get-requests with query-string", async () => {
       gcpFakeApi.get("/gcp/some/path").query({ q: "some-query" }).times(2).reply(200, { ok: true });
       const result = await http.asserted.get({ path: "/gcp/some/path", correlationId, qs: { q: "some-query" } });


### PR DESCRIPTION
Allow manually setting an Authorization header when calling functions in the http lib. This lets us run scripts locally by using a gcloud cli produced token.