### PR TITLE
Add ensureCompleteChunks iterator

### DIFF
--- a/lib/utils/iterators.js
+++ b/lib/utils/iterators.js
@@ -1,3 +1,5 @@
+import { StringDecoder } from "string_decoder";
+
 function cons(...o) {
   return async function* (iterables) {
     for await (const iterable of iterables) {
@@ -12,6 +14,16 @@ function decorate(o) {
       yield { ...iterable, attributes: { ...iterable.attributes, ...o } };
     }
   };
+}
+
+async function* ensureCompleteChunks(iterable) {
+  // Returns a decoded string, ensuring that any incomplete multibyte characters at
+  // the end of the chunk are buffered until the next chunk is received.
+  const decoder = new StringDecoder("utf8");
+  for await (const chunk of iterable) {
+    yield decoder.write(chunk);
+  }
+  yield decoder.end();
 }
 
 function inject(o) {
@@ -80,4 +92,4 @@ async function* generate(data) {
   for await (const d of data) yield d;
 }
 
-export { cons, decorate, enumerate, inject, parse, split, stringify, generate, unbuffer };
+export { cons, decorate, ensureCompleteChunks, enumerate, inject, parse, split, stringify, generate, unbuffer };

--- a/test/unit/utils/iterators-test.js
+++ b/test/unit/utils/iterators-test.js
@@ -3,6 +3,7 @@ import stream from "stream";
 import {
   cons,
   decorate,
+  ensureCompleteChunks,
   enumerate,
   inject,
   parse,
@@ -75,6 +76,27 @@ describe("count the records in the stream", () => {
     });
     finalOutput[0].should.eql([ 0, "line1" ]);
     finalOutput[1].should.eql([ 1, "line2" ]);
+  });
+});
+
+describe("ensureCompleteChunks", () => {
+  it("combines separated characters", async () => {
+    let finalOutput = "";
+    await pipeline(Readable.from([ 0xE2, 0x82, 0xAC ].map((c) => Buffer.from([ c ]))), ensureCompleteChunks, async (iterable) => {
+      for await (const o of iterable) {
+        finalOutput += o;
+      }
+    });
+    finalOutput.should.eql("€");
+  });
+  it("handles non-separated characters", async () => {
+    let finalOutput = "";
+    await pipeline(Readable.from(Buffer.from("fish")), ensureCompleteChunks, async (iterable) => {
+      for await (const o of iterable) {
+        finalOutput += o;
+      }
+    });
+    finalOutput.should.eql("fish");
   });
 });
 


### PR DESCRIPTION
WHY?

When reading files from gcs sometimes a utf8 character will be split in two chunks which will break the character. 
This new iterator makes sure that there are no incomplete characters in a chunk.

**Checklist**

- [x] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

## Write the description and the reason for this PR below ↓

https://nodejs.org/api/string_decoder.html