### PR TITLE
Create github release automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if package version changed
+        id: check_version
+        run: |
+          version="v$(cat package.json | jq -r '.version')"
+          if [ $(git tag -l "$version") ]; then
+            echo "Tag $version already exists."
+          else
+            echo "version_tag=$version" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Release
+        if: steps.check_version.outputs.version_tag
+        run: |
+          gh release create ${{ steps.check_version.outputs.version_tag }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically create a github release if the version has changed in `package.json` when merging to master.

Copied straight from [b0rker](https://github.com/BonnierNews/b0rker/blob/main/.github/workflows/release.yml).