### PR TITLE
Add country code for Curacao

### DIFF
--- a/lib/validation-helpers/country-codes.js
+++ b/lib/validation-helpers/country-codes.js
@@ -50,6 +50,7 @@ const countryCodes = [
   "CR",
   "CU",
   "CV",
+  "CW",
   "CX",
   "CY",
   "CZ",


### PR DESCRIPTION
Add CW (Curacao) country code because of a DLX problem (change payment method to Autogiro with an address in Curacao)