### PR TITLE
We're not migrating common namespaces anymore, they're all in (for now)

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,5 +1,3 @@
-import toggle from "./helpers/toggle.js";
-
 const postalDeliveryOnlyNamespaces = [ "paf" ];
 const carrierDeliveryOnlyNamespaces = [ "bnlo", "gotamedia" ];
 
@@ -16,11 +14,9 @@ const bbmNamespaces = [
   "bbm-news",
 ];
 
-// FIXME: "di" should be in commonNamespaces and salesforceCaseNamespaces, but not platformNamespaces once di is completely migrated to common
-// FIXME: bbmNamespaces should be in commonNamespaces once bbm is completely migrated to common
-const commonNamespaces = [ "dn", "expressen", "bnlo", "paf" ];
-const platformNamespaces = [ ...commonNamespaces ];
+const platformNamespaces = [ "dn", "expressen", "bnlo", "paf", "gotamedia" ];
 const salesforceCaseNamespaces = [ ...platformNamespaces, "di" ];
+const commonNamespaces = [ ...platformNamespaces, "di", ...bbmNamespaces ];
 
 function postalDeliveryOnly(namespace) {
   return postalDeliveryOnlyNamespaces.includes(namespace);
@@ -31,26 +27,11 @@ function carrierDeliveryOnly(namespace) {
 }
 
 function isCommonNamespace(namespace) {
-  // FIXME: remove toggle once di is completely migrated to common
-  if (toggle("diInCommonNamespaces") && namespace === "di") return true;
-  // FIXME: remove toggle once bbm is completely migrated to common
-  if (toggle("bbmInCommonNamespaces") && bbmNamespaces.includes(namespace)) return true;
-  // FIXME: remove toggle once gotamedia is completely migrated to common
-  if (toggle("gotamediaInCommonNamespaces") && namespace === "gotamedia") return true;
-
   return commonNamespaces.includes(namespace);
 }
 
 function getCommonNamespaces() {
-  const output = [ ...commonNamespaces ];
-  // FIXME: remove toggle once di is completely migrated to common
-  if (toggle("diInCommonNamespaces")) output.push("di");
-  // FIXME: remove toggle once bbm is completely migrated to common
-  if (toggle("bbmInCommonNamespaces")) output.push(...bbmNamespaces);
-  // FIXME: remove toggle once bbm-news is completely migrated to common
-  if (toggle("gotamediaInCommonNamespaces")) output.push("gotamedia");
-  // FIXME: just return commonNamespaces
-  return output;
+  return commonNamespaces;
 }
 
 export {

--- a/test/unit/namespaces-common-test.js
+++ b/test/unit/namespaces-common-test.js
@@ -1,5 +1,5 @@
 import { isCommonNamespace, getCommonNamespaces } from "../../lib/namespaces.js";
-// FIXME: get rid of expectedNamespacesNoDi, expectedNamespacesNoBbm, expectedNamespacesNoGotaMedia + related test once di and bbm have migrated
+
 const expectedNamespaces = [
   "bbm-aktuellhallbarhet",
   "bbm-byggindustrin",
@@ -18,113 +18,6 @@ const expectedNamespaces = [
   "gotamedia",
   "paf",
 ];
-const expectedNamespacesNoDi = [
-  "bbm-aktuellhallbarhet",
-  "bbm-byggindustrin",
-  "bbm-dagensmedicin",
-  "bbm-dagenssamhalle",
-  "bbm-dagligvarunytt",
-  "bbm-dam",
-  "bbm-fastighetsnytt",
-  "bbm-market",
-  "bbm-news",
-  "bbm-res",
-  "bnlo",
-  "dn",
-  "expressen",
-  "gotamedia",
-  "paf",
-];
-const expectedNamespacesNoBbm = [ "bnlo", "di", "dn", "expressen", "gotamedia", "paf" ];
-const expectedNamespacesNoGotaMedia = [
-  "bbm-aktuellhallbarhet",
-  "bbm-byggindustrin",
-  "bbm-dagensmedicin",
-  "bbm-dagenssamhalle",
-  "bbm-dagligvarunytt",
-  "bbm-dam",
-  "bbm-fastighetsnytt",
-  "bbm-market",
-  "bbm-news",
-  "bbm-res",
-  "bnlo",
-  "di",
-  "dn",
-  "expressen",
-  "paf",
-];
-
-describe("isCommonNamespace (di toggled off)", () => {
-  beforeEach(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = "diInCommonNamespaces";
-  });
-  after(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = undefined;
-  });
-  expectedNamespacesNoDi.forEach((namespace) => {
-    it(`should confirm '${namespace}' as part of common namespace`, () => {
-      const result = isCommonNamespace(namespace);
-      result.should.equal(true);
-    });
-  });
-
-  it("should NOT confirm 'di' as part of common namespace", () => {
-    const result = isCommonNamespace("di");
-    result.should.equal(false);
-  });
-
-  it("should give us a list of common namespaces", () => {
-    JSON.stringify(getCommonNamespaces().sort()).should.equal(JSON.stringify(expectedNamespacesNoDi));
-  });
-});
-
-describe("isCommonNamespace (bbm-* toggled off)", () => {
-  beforeEach(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = "bbmInCommonNamespaces";
-  });
-  after(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = undefined;
-  });
-  expectedNamespacesNoBbm.forEach((namespace) => {
-    it(`should confirm '${namespace}' as part of common namespace`, () => {
-      const result = isCommonNamespace(namespace);
-      result.should.equal(true);
-    });
-  });
-
-  it("should NOT confirm 'bbm-dam' as part of common namespace", () => {
-    const result = isCommonNamespace("bbm-dam");
-    result.should.equal(false);
-  });
-
-  it("should give us a list of common namespaces", () => {
-    JSON.stringify(getCommonNamespaces().sort()).should.equal(JSON.stringify(expectedNamespacesNoBbm));
-  });
-});
-
-describe("isCommonNamespace (gotamedia toggled off)", () => {
-  beforeEach(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = "gotamediaInCommonNamespaces";
-  });
-  after(() => {
-    process.env["NODE-DISABLE-TOGGLE"] = undefined;
-  });
-  expectedNamespacesNoGotaMedia.forEach((namespace) => {
-    it(`should confirm '${namespace}' as part of common namespace`, () => {
-      const result = isCommonNamespace(namespace);
-      result.should.equal(true);
-    });
-  });
-
-  it("should NOT confirm 'di' as part of common namespace", () => {
-    const result = isCommonNamespace("gotamedia");
-    result.should.equal(false);
-  });
-
-  it("should give us a list of common namespaces", () => {
-    JSON.stringify(getCommonNamespaces().sort()).should.equal(JSON.stringify(expectedNamespacesNoGotaMedia));
-  });
-});
 
 describe("isCommonNamespace", () => {
   expectedNamespaces.forEach((namespace) => {


### PR DESCRIPTION
Cleanup the FIXMEs for common and platform namespaces now that all the relevant namespaces have migrated into the common (credentials) namespace
