### PR TITLE
joi-postcode doesn't know about Curaçao either

### DIFF
--- a/lib/validation-helpers/schemas.js
+++ b/lib/validation-helpers/schemas.js
@@ -37,6 +37,10 @@ const customZipCodeValidation = function (value) {
 };
 
 function isValidZipCode(zipCode, country = "SE") {
+  if (country === "CW") {
+    if ([ undefined, "0000" ].includes(zipCode)) return;
+    return { details: [ { message: 'Curaçao doesn\'t have postal codes, use "0000"' } ] };
+  }
   const { error } = joi.string().postalCode(country).validate(zipCode); // Validation doesn't care about whitespaces.
   return error;
 }

--- a/test-data/unit/validation-helpers/schemas-test-data.js
+++ b/test-data/unit/validation-helpers/schemas-test-data.js
@@ -20,7 +20,7 @@ const addressScenarios = [
     },
   },
   {
-    text: "Valid foregin address",
+    text: "Valid foreign address",
     expected: true,
     address: {
       streetName: "Awesome street in canada",
@@ -28,6 +28,29 @@ const addressScenarios = [
       zipCode: "S0J 2Y0",
       city: "Saskatchewan",
       country: "CA",
+    },
+  },
+  {
+    text: "Valid address in obscure country (Curaçao)",
+    expected: true,
+    address: {
+      city: "Willemstad",
+      country: "CW",
+      streetName: "Telamonstraat",
+      streetNumber: "59",
+      zipCode: "0000",
+    },
+  },
+  {
+    text: "Invalid address in obscure country (Curaçao)",
+    expected: false,
+    error: '"zipCode" failed validation because Curaçao doesn\'t have postal codes, use "0000"',
+    address: {
+      city: "Willemstad",
+      country: "CW",
+      streetName: "Telamonstraat",
+      streetNumber: "59",
+      zipCode: "59",
     },
   },
   {
@@ -184,7 +207,7 @@ const addressScenarios = [
     },
   },
   {
-    text: "Invalid address cause of invalid foregin zipcode",
+    text: "Invalid address cause of invalid foreign zipcode",
     expected: false,
     error: '"zipCode" failed validation because Postal code 12 is not valid for country US',
     address: {


### PR DESCRIPTION
Implement a workaround in address validation for an obscure little country that joi-postcode doesn't know about.
