### PR TITLE
Fix alt title for Ljusnan

### DIFF
--- a/config/print-mapping.js
+++ b/config/print-mapping.js
@@ -571,7 +571,7 @@ const productConfig = {
     },
     {
       title: "lj",
-      alternativeTitles: [ "ljudalsposten" ],
+      alternativeTitles: [ "ljusnan" ],
       tsCode: "1230",
       shortName: "",
       subDirectory: "",


### PR DESCRIPTION
**Reason**

Local uses `ljusnan` when checking deviations

**Description**

Fix `ljusnan` as valid alternative title for Ljusnan

[Link](https://favro.com/organization/a75be0396fe39314c7ac300f/fdaea1f08a3e304708565fd5?card=Bon-154140) to card in Favro


---

Write the description and the reason for this PR above ⇧

**Checklist (tick all the boxes)**

- have you done the following:
  - [ ] tested in lab
  - [x] reviewed the code yourself
- have you checked if the following need an update:
  - [x] configs
  - [x] readme
  - [x] coverage (Update .c8rc in that case.)
