### PR TITLE
Expose all titles in a format that is useful to us

### DIFF
--- a/lib/titles.js
+++ b/lib/titles.js
@@ -43,6 +43,10 @@ function getTitlesByNamespace(namespace) {
   return productConfig[namespace].map((pm) => pm.title).filter((t) => t);
 }
 
+const allTitles = productMapping.filter((pm) => pm.title).map((pm) => {
+  return { title: pm.title, namespace: pm.namespace, name: pm.productName };
+});
+
 export {
   postalDeliveryAllowed,
   getAllPrintTitles,
@@ -51,4 +55,5 @@ export {
   getTitlesByNamespace,
   productMapping,
   productConfig,
+  allTitles,
 };


### PR DESCRIPTION
zuora-api wants `{ title, namespace, name }`
