### PR TITLE
Add get namespace by title function

### DIFF
--- a/lib/titles.js
+++ b/lib/titles.js
@@ -43,12 +43,19 @@ function getTitlesByNamespace(namespace) {
   return productConfig[namespace].map((pm) => pm.title).filter((t) => t);
 }
 
+function getNamespaceByTitle(title) {
+  const namespaceByRealTitle = productMapping.find((pm) => pm.title === title)?.namespace;
+  if (namespaceByRealTitle) return namespaceByRealTitle;
+  return productMapping.find((pm) => pm.alternativeTitles?.includes(title))?.namespace;
+}
+
 export {
   postalDeliveryAllowed,
   getAllPrintTitles,
   getPrintTitlesByNamespace,
   getAllTitles,
   getTitlesByNamespace,
+  getNamespaceByTitle,
   productMapping,
   productConfig,
 };

--- a/test/unit/titles-get-namespace-by-title-test.js
+++ b/test/unit/titles-get-namespace-by-title-test.js
@@ -1,0 +1,20 @@
+import { getNamespaceByTitle } from "../../lib/titles.js";
+
+const testCases = [
+  { title: "dn", namespace: "dn" },
+  { title: "di", namespace: "di" },
+  { title: "expressen", namespace: "expressen" },
+  { title: "lj", namespace: "bnlo" }, // a local title by real title
+  { title: "ljusnan", namespace: "bnlo" }, // the same local title by alternative title
+  { title: "paf", namespace: "paf" },
+  { title: "smp", namespace: "gotamedia" },
+];
+
+describe("get namespace by title", () => {
+  for (const tc of testCases) {
+    it(`should return ${tc.namespace} for: ${tc.title}`, () => {
+      const namespace = getNamespaceByTitle(tc.title);
+      namespace.should.eql(tc.namespace);
+    });
+  }
+});


### PR DESCRIPTION
zuora-api just uses the title list to figure out namespace (in cancel-subscription). Seems like a useful thing to be able to do, so lets expose it here.