### PR TITLE
Restrict all address fields to same max length as Salesforce allows

### DIFF
--- a/lib/validation-helpers/schemas.js
+++ b/lib/validation-helpers/schemas.js
@@ -60,21 +60,21 @@ const addressSchema = joi
     return errors;
   })
   .keys({
-    streetName: joi.string().required(),
-    streetNumber: joi.string().optional().allow(null),
-    stairCase: joi.string().optional().allow(null),
-    stairs: joi.string().optional().allow(null),
-    apartmentNumber: joi.string().optional().allow(null),
-    zipCode: joi.string().required(), // ZipCode validation in our customValidation above.
-    city: joi.string().required(),
+    streetName: joi.string().required().max(50),
+    streetNumber: joi.string().optional().allow(null).max(50),
+    stairCase: joi.string().optional().allow(null).max(50),
+    stairs: joi.string().optional().allow(null).max(50),
+    apartmentNumber: joi.string().optional().allow(null).max(50),
+    zipCode: joi.string().required().max(50), // ZipCode validation in our customValidation above.
+    city: joi.string().required().max(50),
     country: joi
       .string()
       .allow(null)
       .default("SE")
-      .valid(...validCountries),
-    careOf: joi.string().optional().allow(null),
-    companyName: joi.string().optional().allow(null),
-    deliveryMethod: joi.string().optional().allow(null).valid("POST"),
+      .valid(...validCountries), // no need to limit the length since we restrict to a list anyway but SF allows max(50)
+    careOf: joi.string().optional().allow(null).max(255),
+    companyName: joi.string().optional().allow(null).max(50),
+    deliveryMethod: joi.string().optional().allow(null).valid("POST").max(255),
   });
 
 const distributionFeeSchema = joi.object().keys({

--- a/test-data/unit/validation-helpers/schemas-test-data.js
+++ b/test-data/unit/validation-helpers/schemas-test-data.js
@@ -1,23 +1,25 @@
 import stripSchemaTag from "../../../lib/validation-helpers/strip-schema-tag.js";
 import { addressSchema } from "../../../lib/validation-helpers/schemas.js";
 
+const defaultAddress = {
+  streetName: "Testgatan",
+  streetNumber: "1",
+  stairCase: "A",
+  stairs: "1",
+  apartmentNumber: "1101",
+  zipCode: "12345",
+  city: "Teststaden",
+  careOf: "Bestefar",
+  companyName: "AwesomeCompany AB",
+  country: "SE",
+  deliveryMethod: "POST",
+};
+
 const addressScenarios = [
   {
     text: "Valid address with all the fields",
     expected: true,
-    address: {
-      streetName: "Testgatan",
-      streetNumber: "1",
-      stairCase: "A",
-      stairs: "1",
-      apartmentNumber: "1101",
-      zipCode: "12345",
-      city: "Teststaden",
-      careOf: "Bestefar",
-      companyName: "AwesomeCompany AB",
-      country: "SE",
-      deliveryMethod: "POST",
-    },
+    address: defaultAddress,
   },
   {
     text: "Valid foreign address",
@@ -253,6 +255,20 @@ const addressScenarios = [
     address: {},
   },
 ];
+
+for (const key of Object.keys(addressSchema.describe().keys).filter(
+  (k) => ![ "country", "deliveryMethod" ].includes(k)
+)) {
+  const badAddress = JSON.parse(JSON.stringify(defaultAddress));
+  badAddress[key] = Buffer.alloc(500, "Hej").toString();
+  const allowedLength = key === "careOf" ? 255 : 50;
+  addressScenarios.push({
+    text: `Invalid address with long ${key}`,
+    expected: false,
+    address: badAddress,
+    error: `"${key}" length must be less than or equal to ${allowedLength} characters long`,
+  });
+}
 
 const distributionFeeScenarios = [
   {


### PR DESCRIPTION
Salesforce limits most address fields to 50 characters in length.

Prior to this PR our joi schema allowed any length, which would cause orders containing invalid fields to end up on the DLX for manual fix.

By including the restriction in the joi schema, we can stop the orders before they come in which gives the end user a chance to fix it as they wish first.