### PR TITLE
Expressen now has 6 day delivery

### DIFF
--- a/config/product-mapping.js
+++ b/config/product-mapping.js
@@ -74,7 +74,7 @@ const productConfig = {
       modexProducts: [ { productName: "Expressen", productCode: "EX" } ],
       diCustomerSystem: "EXPA",
       diTitle: "EX Expressen",
-      deliveryDays: sevenDay,
+      deliveryDays: sixDay,
     },
     {
       title: "sportexpressen",
@@ -89,7 +89,7 @@ const productConfig = {
       modexProducts: [ { productName: "Göteborgstidningen", productCode: "GT" } ],
       diCustomerSystem: "GTI",
       diTitle: "EX Göteborgstidningen",
-      deliveryDays: sevenDay,
+      deliveryDays: sixDay,
     },
     {
       title: "kvp",
@@ -100,6 +100,7 @@ const productConfig = {
       modexProducts: [ { productName: "Kvällsposten", productCode: "KV" } ],
       diCustomerSystem: "KVP",
       diTitle: "EX Kvällsposten",
+      deliveryDays: sixDay,
     },
     {
       title: null,


### PR DESCRIPTION
Since April 2024 Expressen is only published Monday to Saturday. 

We haven't really had support for that previously. Now with the changes made for Local and Gota Media we can manage the tot and diff file sequences successfully for 6 day publication, so it's time to switch (and make Early Bird happy by no longer sending Sunday files for Expressen).

Don't merge this until the [PR ](https://github.com/BonnierNews/lu-greenfield/pull/5911)in Greenfield is ready.
