### PR TITLE
Only allow numbers in streetNumber string

### DIFF
--- a/lib/utils/get-url.js
+++ b/lib/utils/get-url.js
@@ -12,7 +12,9 @@ function getUrl(params) {
 
 function parse(baseUrl, path) {
   const baseUrlWithProtocol = baseUrl.startsWith("http") ? baseUrl : `https://${baseUrl}`;
-  const baseUrlWithoutEndSlash = baseUrlWithProtocol.endsWith("/") ? baseUrlWithProtocol.slice(0, -1) : baseUrlWithProtocol;
+  const baseUrlWithoutEndSlash = baseUrlWithProtocol.endsWith("/")
+    ? baseUrlWithProtocol.slice(0, -1)
+    : baseUrlWithProtocol;
   const url = new URL(`${baseUrlWithoutEndSlash}${path}`);
   return url.href;
 }

--- a/lib/validation-helpers/schemas.js
+++ b/lib/validation-helpers/schemas.js
@@ -61,7 +61,7 @@ const addressSchema = joi
   })
   .keys({
     streetName: joi.string().required().max(50),
-    streetNumber: joi.string().optional().allow(null).max(50),
+    streetNumber: joi.string().pattern(new RegExp("^[0-9]+$")).optional().allow(null).max(50).messages({ "string.pattern.base": '"streetNumber" length must be less than or equal to 50 characters long' }),
     stairCase: joi.string().optional().allow(null).max(50),
     stairs: joi.string().optional().allow(null).max(50),
     apartmentNumber: joi.string().optional().allow(null).max(50),

--- a/lib/validation-helpers/schemas.js
+++ b/lib/validation-helpers/schemas.js
@@ -61,7 +61,13 @@ const addressSchema = joi
   })
   .keys({
     streetName: joi.string().required().max(50),
-    streetNumber: joi.string().pattern(new RegExp("^[0-9]+$")).optional().allow(null).max(50).messages({ "string.pattern.base": '"streetNumber" length must be less than or equal to 50 characters long' }),
+    streetNumber: joi
+      .string()
+      .pattern(new RegExp("(^[\\-\\d]+$)|(^[a-öA-Ö]+$)"))
+      .optional()
+      .allow(null)
+      .max(50)
+      .messages({ "string.pattern.base": '"streetNumber" length must be less than or equal to 50 characters long' }),
     stairCase: joi.string().optional().allow(null).max(50),
     stairs: joi.string().optional().allow(null).max(50),
     apartmentNumber: joi.string().optional().allow(null).max(50),

--- a/test-data/unit/validation-helpers/schemas-test-data.js
+++ b/test-data/unit/validation-helpers/schemas-test-data.js
@@ -115,6 +115,40 @@ const addressScenarios = [
     },
   },
   {
+    text: "Valid address with negative streetNumber",
+    expected: true,
+    address: {
+      streetName: "Testgatan",
+      streetNumber: "-39",
+      zipCode: "12345",
+      city: "Teststaden",
+      country: "SE",
+    },
+  },
+  {
+    text: "Valid address with only letters as streetNumber",
+    expected: true,
+    address: {
+      streetName: "Testgatan",
+      streetNumber: "ABC",
+      zipCode: "12345",
+      city: "Teststaden",
+      country: "SE",
+    },
+  },
+  {
+    text: "Invalid address due to bad streetNumber 1A",
+    expected: false,
+    error: '"streetNumber" length must be less than or equal to 50 characters long',
+    address: {
+      streetName: "Testgatan",
+      streetNumber: "1A",
+      zipCode: "12345",
+      city: "Teststaden",
+      country: "SE",
+    },
+  },
+  {
     text: "Invalid address default country address, bad zipCode",
     expected: false,
     error: '"zipCode" failed validation because Postal code 123 is not valid for country SE',

--- a/test/unit/validation-helpers/schemas-test.js
+++ b/test/unit/validation-helpers/schemas-test.js
@@ -31,19 +31,6 @@ describe("check if address is correct", () => {
   }
 });
 
-describe("check if address is NOT correct", () => {
-  it("should invalidate address with a letter in streetNumber", () => {
-    const notValidAddress = addressSchema.validate({
-      streetName: "Testgatan",
-      streetNumber: "1A",
-      zipCode: "12345",
-      city: "Teststaden",
-    });
-
-    notValidAddress.error.details[0].message.should.eql('"streetNumber" length must be less than or equal to 50 characters long');
-  });
-});
-
 describe("check if distributionFee is correct", () => {
   for (const s of distributionFeeScenarios) {
     describe(`${s.text || s.nandText} with nand schema`, () => {

--- a/test/unit/validation-helpers/schemas-test.js
+++ b/test/unit/validation-helpers/schemas-test.js
@@ -12,6 +12,7 @@ describe("check if address is correct", () => {
         : addressSchema.validate(s.address);
 
       it(`is a${s.expected ? " valid " : "n invalid "} address`, () => {
+
         Boolean(!notValidAddress).should.eql(Boolean(s.expected));
       });
 
@@ -28,6 +29,19 @@ describe("check if address is correct", () => {
       }
     });
   }
+});
+
+describe("check if address is NOT correct", () => {
+  it("should invalidate address with a letter in streetNumber", () => {
+    const notValidAddress = addressSchema.validate({
+      streetName: "Testgatan",
+      streetNumber: "1A",
+      zipCode: "12345",
+      city: "Teststaden",
+    });
+
+    notValidAddress.error.details[0].message.should.eql('"streetNumber" length must be less than or equal to 50 characters long');
+  });
 });
 
 describe("check if distributionFee is correct", () => {


### PR DESCRIPTION
**Checklist**

- [ ] Was the code tested in lab?
- [x] Have you reviewed the code yourself?
- [x] Are the configs updated?
- [x] Does the readme need an update?

## Write the description and the reason for this PR below ↓
Currently we're allowing streetNumber to have values as "1A", which should be streetNumber 1, stairCase A. This causes problems at distribution innovation later on.

This a one part of the fixes needed here.

https://favro.com/organization/a75be0396fe39314c7ac300f/fdaea1f08a3e304708565fd5?card=Bon-166377