### PR TITLE
Don't keepalive HTTP requests by default

### DIFF
--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -1,6 +1,8 @@
 import assert from "assert";
 import axios from "axios";
 import config from "exp-config";
+import http from "http";
+import https from "https";
 import { debugMeta, logger } from "lu-logger";
 import util from "util";
 
@@ -8,6 +10,11 @@ import { getGcpAuthHeaders } from "./gcp-auth.js";
 import getUrl from "./get-url.js";
 
 const backends = buildBackends();
+
+const httpAgent = new http.Agent({ keepAlive: false });
+const httpsAgent = new https.Agent({ keepAlive: false });
+const httpAgentKeepAlive = new http.Agent({ keepAlive: true });
+const httpsAgentKeepAlive = new https.Agent({ keepAlive: true });
 
 async function performRequest(method, params) {
   assert(config.appName, "appName must be set in config");
@@ -44,6 +51,14 @@ async function performRequest(method, params) {
   }
   if (params.paramsSerializer) {
     opts.paramsSerializer = params.paramsSerializer;
+  }
+
+  if (params.keepAlive) {
+    opts.httpAgent = httpAgentKeepAlive;
+    opts.httpsAgent = httpsAgentKeepAlive;
+  } else {
+    opts.httpAgent = httpAgent;
+    opts.httpsAgent = httpsAgent;
   }
 
   let response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-common",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-common",
-      "version": "9.0.3",
+      "version": "9.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-common",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "description": "",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
HTTP keepalive was enabled by default in Node 20, and is apparently causing errors for axios. This is an attempt at remedying that.

See e.g. https://github.com/nodejs/node/issues/47130, https://github.com/axios/axios/issues/6113.
