### PR TITLE
Make sure that alternative titles are handled properly

### DIFF
--- a/lib/titles.js
+++ b/lib/titles.js
@@ -33,7 +33,7 @@ const alternativeTitleConfig = productMapping
   .filter((p) => p.alternativeTitles)
   .flatMap((p) =>
     p.alternativeTitles.map((t) => {
-      return { ...p, alternativeTitles: undefined, title: t };
+      return { ...p, title: t };
     })
   );
 const realTitlesConfig = productMapping.filter((p) => p.title);

--- a/lib/titles.js
+++ b/lib/titles.js
@@ -29,35 +29,43 @@ Object.keys(productConfig).forEach((namespace) => {
   });
 });
 
+const alternativeTitleConfig = productMapping
+  .filter((p) => p.alternativeTitles)
+  .flatMap((p) =>
+    p.alternativeTitles.map((t) => {
+      return { ...p, alternativeTitles: undefined, title: t };
+    })
+  );
+const realTitlesConfig = productMapping.filter((p) => p.title);
+const allTitlesConfig = [ ...realTitlesConfig, ...alternativeTitleConfig ];
+
 function getAllPrintTitles() {
-  return productMapping.filter((pm) => pm.tsCode).map((pm) => pm.title);
+  return realTitlesConfig.filter((p) => p.tsCode).map((p) => p.title);
 }
 
 function getPrintTitlesByNamespace(namespace) {
-  return productConfig[namespace]
-    .filter((pm) => pm.tsCode)
-    .map((pm) => pm.title)
-    .filter((t) => t);
+  return realTitlesConfig.filter((p) => p.tsCode && p.namespace === namespace).map((p) => p.title);
 }
 
 function getAllTitles() {
-  return productMapping.filter((pm) => pm.title).map((pm) => pm.title);
+  return realTitlesConfig.map((p) => p.title);
 }
 
 function getTitlesByNamespace(namespace) {
-  return productConfig[namespace].map((pm) => pm.title).filter((t) => t);
+  return realTitlesConfig.filter((p) => p.namespace === namespace).map((p) => p.title);
 }
 
 function getTitleConfig(title) {
-  return productMapping.find(
-    (p) => p.title === title || (p.alternativeTitles && p.alternativeTitles.includes(title))
-  );
+  return productMapping.find((p) => p.title === title || (p.alternativeTitles && p.alternativeTitles.includes(title)));
 }
 
 function getDeliveryDays(namespace, title) {
   const product = getTitleConfig(title);
   assert(product?.deliveryDays, `No delivery days for title ${title} was found. Update product-mapping config`);
-  assert(product.namespace === namespace, `title ${title} not valid for namespace ${namespace}. Check product-mapping config`);
+  assert(
+    product.namespace === namespace,
+    `title ${title} not valid for namespace ${namespace}. Check product-mapping config`
+  );
   return product?.deliveryDays;
 }
 
@@ -136,6 +144,8 @@ function getNamespaceByTitle(title) {
 }
 
 export {
+  alternativeTitleConfig,
+  allTitlesConfig,
   deliveryDaysToNumberOfJobs,
   numberOfJobsToJobOffsets,
   postalDeliveryAllowed,
@@ -148,5 +158,6 @@ export {
   getNamespaceByTitle,
   productMapping,
   productConfig,
+  realTitlesConfig,
   validNamespaces,
 };

--- a/lib/titles.js
+++ b/lib/titles.js
@@ -49,14 +49,15 @@ function getTitlesByNamespace(namespace) {
 }
 
 function getTitleConfig(title) {
-  const configByRealTitle = productMapping.find((pm) => pm.title === title);
-  if (configByRealTitle) return configByRealTitle;
-  return productMapping.find((pm) => pm.alternativeTitles?.includes(title));
+  return productMapping.find(
+    (p) => p.title === title || (p.alternativeTitles && p.alternativeTitles.includes(title))
+  );
 }
 
 function getDeliveryDays(namespace, title) {
-  const product = productConfig[namespace].find((p) => p.title === title);
-  assert(product?.deliveryDays, "No delivery days for title was found. Update product-mapping config");
+  const product = getTitleConfig(title);
+  assert(product?.deliveryDays, `No delivery days for title ${title} was found. Update product-mapping config`);
+  assert(product.namespace === namespace, `title ${title} not valid for namespace ${namespace}. Check product-mapping config`);
   return product?.deliveryDays;
 }
 
@@ -129,9 +130,9 @@ function numberOfJobsToJobOffsets(numberOfJobs) {
 }
 
 function getNamespaceByTitle(title) {
-  const namespaceByRealTitle = productMapping.find((pm) => pm.title === title)?.namespace;
-  if (namespaceByRealTitle) return namespaceByRealTitle;
-  return productMapping.find((pm) => pm.alternativeTitles?.includes(title))?.namespace;
+  const product = getTitleConfig(title);
+  assert(product, `title ${title} not found in product-mapping. Check product-mapping config`);
+  return product.namespace;
 }
 
 export {

--- a/lib/utils/get-url.js
+++ b/lib/utils/get-url.js
@@ -12,7 +12,9 @@ function getUrl(params) {
 
 function parse(baseUrl, path) {
   const baseUrlWithProtocol = baseUrl.startsWith("http") ? baseUrl : `https://${baseUrl}`;
-  const baseUrlWithoutEndSlash = baseUrlWithProtocol.endsWith("/") ? baseUrlWithProtocol.slice(0, -1) : baseUrlWithProtocol;
+  const baseUrlWithoutEndSlash = baseUrlWithProtocol.endsWith("/")
+    ? baseUrlWithProtocol.slice(0, -1)
+    : baseUrlWithProtocol;
   const url = new URL(`${baseUrlWithoutEndSlash}${path}`);
   return url.href;
 }

--- a/test/unit/titles-alternative-titles-test.js
+++ b/test/unit/titles-alternative-titles-test.js
@@ -1,0 +1,71 @@
+/* eslint-disable import/namespace */
+import * as titles from "../../lib/titles.js";
+
+const allFunctions = Object.keys(titles)
+  .filter((f) => typeof titles[f] === "function")
+  .map((f) => {
+    return { name: f, params: getParams(titles[f]) };
+  });
+const titleFunctions = allFunctions.filter((f) => f.params.includes("title"));
+
+describe("check that alternative titles work everywhere that title does", () => {
+  titleFunctions.forEach((f) => {
+    it(`should return the same result for function ${f.name} with title and alternative title`, () => {
+      const params = mapParams(f.params, "bnlo", "ht");
+      const alternativeParams = mapParams(f.params, "bnlo", "hudiksvalsstidning");
+
+      const result = titles[f.name](...params);
+      const resultAlternative = titles[f.name](...alternativeParams);
+
+      result.should.eql(resultAlternative);
+    });
+  });
+});
+
+function mapParams(params, namespace, title) {
+  return params.map((p) => {
+    if (p === "title") return title;
+    if (p === "namespace") return namespace;
+    throw new Error(`Test can't currently handle parameter ${p}, fix it!`);
+  });
+}
+
+function getParams(func) {
+  // courtesy of Geeks for Geeks
+  // https://www.geeksforgeeks.org/how-to-get-the-javascript-function-parameter-names-values-dynamically/#:~:text=Approach%3A%20JavaScript%20contains%20a%20method,equivalent%20using%20toString()%20method.
+
+  // String representation of the function code
+  let str = func.toString();
+
+  // Remove comments of the form /* ... */
+  // Removing comments of the form //
+  // Remove body of the function { ... }
+  // removing '=>' if func is arrow function
+  str = str
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/(.)*/g, "")
+    .replace(/{[\s\S]*}/, "")
+    .replace(/=>/g, "")
+    .trim();
+
+  // Start parameter names after first '('
+  const start = str.indexOf("(") + 1;
+
+  // End parameter names is just before last ')'
+  const end = str.length - 1;
+
+  const result = str.substring(start, end).split(", ");
+
+  const params = [];
+
+  result.forEach((element) => {
+    // Removing any default value
+    element = element.replace(/=[\s\S]*/g, "").trim();
+
+    if (element.length > 0) {
+      params.push(element);
+    }
+  });
+
+  return params;
+}

--- a/test/unit/titles-get-delivery-days-test.js
+++ b/test/unit/titles-get-delivery-days-test.js
@@ -8,12 +8,22 @@ describe("get delivery days", () => {
     });
   });
 
-  describe("get delivery days for title that does not have any deliverDays configured", () => {
+  describe("get delivery days for title that does not have any deliveryDays configured", () => {
     it("should throw an error", () => {
       try {
         getDeliveryDays("paf", "pff");
       } catch (error) {
-        error.message.should.eql("No delivery days for title was found. Update product-mapping config");
+        error.message.should.eql("No delivery days for title pff was found. Update product-mapping config");
+      }
+    });
+  });
+
+  describe("get delivery days for title in wrong namespace", () => {
+    it("should throw an error", () => {
+      try {
+        getDeliveryDays("paf", "dn");
+      } catch (error) {
+        error.message.should.eql("title dn not valid for namespace paf. Check product-mapping config");
       }
     });
   });

--- a/test/unit/titles-get-namespace-by-title-test.js
+++ b/test/unit/titles-get-namespace-by-title-test.js
@@ -17,4 +17,11 @@ describe("get namespace by title", () => {
       namespace.should.eql(tc.namespace);
     });
   }
+  it("should raise an error for a title that does not exist", () => {
+    try {
+      getNamespaceByTitle("some-title");
+    } catch (error) {
+      error.message.should.eql("title some-title not found in product-mapping. Check product-mapping config");
+    }
+  });
 });

--- a/test/unit/titles-get-titles-test.js
+++ b/test/unit/titles-get-titles-test.js
@@ -1,4 +1,6 @@
 import {
+  alternativeTitleConfig,
+  allTitlesConfig,
   getAllTitles,
   getAllPrintTitles,
   getTitleConfig,
@@ -6,6 +8,7 @@ import {
   getTitlesByNamespace,
   getPrintTitlesByNamespace,
   productConfig,
+  realTitlesConfig,
 } from "../../lib/titles.js";
 
 const namespaceSafety = [
@@ -94,6 +97,33 @@ describe("get titles", () => {
     });
     it("should expect expressen to have so few subscriptions that there won't necessarily be a start/stop file every day", () => {
       Boolean(getTitleConfig("expressen").expectDiffFileEveryDeliveryDay).should.eql(false);
+    });
+  });
+
+  describe("title lists", () => {
+    it("should provide a list of all titles with config", () => {
+      const numTitles = productMapping.filter((p) => p.title).length;
+      realTitlesConfig.length.should.eql(numTitles);
+
+      const expectedConfig = productMapping.find((p) => p.title === realTitlesConfig[0].title);
+      realTitlesConfig[0].should.eql(expectedConfig);
+    });
+    it("should provide a list of all alternative titles with config", () => {
+      const numAlternativeTitles = productMapping
+        .filter((p) => p.alternativeTitles)
+        .reduce((acc, p) => acc + p.alternativeTitles.length, 0);
+      alternativeTitleConfig.length.should.eql(numAlternativeTitles);
+
+      const expectedConfig = {
+        ...productMapping
+          .filter((p) => p.alternativeTitles)
+          .find((p) => p.alternativeTitles.includes(alternativeTitleConfig[0].title)),
+        title: alternativeTitleConfig[0].title,
+      };
+      alternativeTitleConfig[0].should.eql(expectedConfig);
+    });
+    it("should provide a list of titles including alternative titles", () => {
+      allTitlesConfig.should.eql([ ...realTitlesConfig, ...alternativeTitleConfig ]);
     });
   });
 });

--- a/test/unit/titles-get-titles-test.js
+++ b/test/unit/titles-get-titles-test.js
@@ -21,14 +21,14 @@ describe("get titles", () => {
   describe("getting all titles", () => {
     it("should return all titles", () => {
       const allTitles = getAllTitles();
-      const allTitlesFromConfig = productMapping.filter((pm) => pm.title).map((pm) => pm.title);
-      allTitles.should.eql(allTitlesFromConfig);
+      const allTitlesFromConfig = productMapping.filter((p) => p.title).map((p) => p.title);
+      allTitles.sort().should.eql(allTitlesFromConfig.sort());
     });
 
     it("should return all print titles", () => {
       const allTitles = getAllPrintTitles();
-      const allTitlesFromConfig = productMapping.filter((pm) => pm.tsCode).map((pm) => pm.title);
-      allTitles.should.eql(allTitlesFromConfig);
+      const allTitlesFromConfig = productMapping.filter((p) => p.title && p.tsCode).map((p) => p.title);
+      allTitles.sort().should.eql(allTitlesFromConfig.sort());
     });
   });
 
@@ -37,7 +37,7 @@ describe("get titles", () => {
       describe(n.text, () => {
         it(`should return all titles in namespace: ${n.namespace}`, () => {
           const titles = getTitlesByNamespace(n.namespace);
-          const titlesFromConfig = productConfig[n.namespace].map((pm) => pm.title).filter((t) => t);
+          const titlesFromConfig = productConfig[n.namespace].map((p) => p.title).filter((t) => t);
           titles.should.eql(titlesFromConfig);
         });
 

--- a/test/unit/titles-get-titles-test.js
+++ b/test/unit/titles-get-titles-test.js
@@ -100,27 +100,33 @@ describe("get titles", () => {
     });
   });
 
-  describe("title lists", () => {
-    it("should provide a list of all titles with config", () => {
-      const numTitles = productMapping.filter((p) => p.title).length;
-      realTitlesConfig.length.should.eql(numTitles);
-
-      const expectedConfig = productMapping.find((p) => p.title === realTitlesConfig[0].title);
-      realTitlesConfig[0].should.eql(expectedConfig);
+  describe("title config lists", () => {
+    describe("real titles", () => {
+      it("should have the right number of products with a title", () => {
+        const numTitles = productMapping.filter((p) => p.title).length;
+        realTitlesConfig.length.should.eql(numTitles);
+      });
+      it("should have the full config of the first product with a title", () => {
+        const expectedConfig = productMapping.find((p) => p.title === realTitlesConfig[0].title);
+        realTitlesConfig[0].should.eql(expectedConfig);
+      });
     });
-    it("should provide a list of all alternative titles with config", () => {
-      const numAlternativeTitles = productMapping
-        .filter((p) => p.alternativeTitles)
-        .reduce((acc, p) => acc + p.alternativeTitles.length, 0);
-      alternativeTitleConfig.length.should.eql(numAlternativeTitles);
-
-      const expectedConfig = {
-        ...productMapping
+    describe("alternative titles", () => {
+      it("should have a product per alternative title", () => {
+        const numAlternativeTitles = productMapping
           .filter((p) => p.alternativeTitles)
-          .find((p) => p.alternativeTitles.includes(alternativeTitleConfig[0].title)),
-        title: alternativeTitleConfig[0].title,
-      };
-      alternativeTitleConfig[0].should.eql(expectedConfig);
+          .reduce((acc, p) => acc + p.alternativeTitles.length, 0);
+        alternativeTitleConfig.length.should.eql(numAlternativeTitles);
+      });
+      it("should have the full config of the first product's alternative title", () => {
+        const expectedConfig = {
+          ...productMapping
+            .filter((p) => p.alternativeTitles)
+            .find((p) => p.alternativeTitles.includes(alternativeTitleConfig[0].title)),
+          title: alternativeTitleConfig[0].title,
+        };
+        alternativeTitleConfig[0].should.eql(expectedConfig);
+      });
     });
     it("should provide a list of titles including alternative titles", () => {
       allTitlesConfig.should.eql([ ...realTitlesConfig, ...alternativeTitleConfig ]);


### PR DESCRIPTION
- Make sure we can handle alternative titles for all functions that take a title
- provide the titleConfig for all alternative titles too
- general cleanup of titles to reuse functions
- no longer return `null` as a print title